### PR TITLE
Ignore help tags generated by vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Vim generates help tags in doc/tags which is annoying if they are not ignored and you use something like pathogen with git submodules as git marks the submodule as 'dirty'.

I've added a .gitignore file with a rule to ignore the generated tags.
