### PR TITLE
Link the current colorscheme for highlighting

### DIFF
--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -19,11 +19,9 @@ CONTENTS                                                 *easymotion-contents*
     3. Requirements ....................... |easymotion-requirements|
     4. Configuration ...................... |easymotion-configuration|
        4.1 EasyMotion_keys ................ |EasyMotion_keys|
-       4.2 EasyMotion_target_hl ........... |EasyMotion_target_hl|
-       4.3 EasyMotion_shade_hl ............ |EasyMotion_shade_hl|
-       4.4 EasyMotion_do_shade ............ |EasyMotion_do_shade|
-       4.5 EasyMotion_do_mapping .......... |EasyMotion_do_mapping|
-       4.6 Custom mappings ................ |easymotion-custom-mappings|
+       4.2 EasyMotion_do_shade ............ |EasyMotion_do_shade|
+       4.3 EasyMotion_do_mapping .......... |EasyMotion_do_mapping|
+       4.4 Custom mappings ................ |easymotion-custom-mappings|
     5. License ............................ |easymotion-license|
     6. Known bugs ......................... |easymotion-known-bugs|
     7. Contributing ....................... |easymotion-contributing|
@@ -122,31 +120,7 @@ keys are available.
 Default: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 ------------------------------------------------------------------------------
-4.2 EasyMotion_target_hl                                *EasyMotion_target_hl*
-
-Set the highlighting group for motion targets. You can override the default
-target highlighting by either changing this variable to another highlighting
-group (e.g. |ErrorMsg|), or by using |hi| to override the default syntax
-colors: >
-
-    hi EasyMotionTarget ctermfg=green ctermbg=black cterm=reverse
-
-Default: 'EasyMotionTarget'
-
-------------------------------------------------------------------------------
-4.3 EasyMotion_shade_hl                                  *EasyMotion_shade_hl*
-
-Set the highlighting group for shaded text (see |EasyMotion_do_shade|). You
-can override the default shade highlighting by either changing this variable
-to another highlighting group, or by using |hi| to override the default syntax
-colors: >
-
-    hi EasyMotionShade ctermfg=red ctermbg=black cterm=none
-
-Default: 'EasyMotionShade'
-
-------------------------------------------------------------------------------
-4.4 EasyMotion_do_shade                                  *EasyMotion_do_shade*
+4.2 EasyMotion_do_shade                                  *EasyMotion_do_shade*
 
 The default behavior is to shade the text following the cursor (forward
 motions) or preceding the cursor (backward motions) to make the motion targets
@@ -155,7 +129,7 @@ more visible. Set this option to 0 if you want to disable text shading.
 Default: 1
 
 ------------------------------------------------------------------------------
-4.5 EasyMotion_do_mapping                              *EasyMotion_do_mapping*
+4.3 EasyMotion_do_mapping                              *EasyMotion_do_mapping*
 
 Set this option to 0 if you want to disable the default mappings. See
 |easymotion-default-mappings| for details about the default mappings.
@@ -167,7 +141,7 @@ this, see |easymotion-custom-mappings| for customizing the default mappings.
 Default: 1
 
 ------------------------------------------------------------------------------
-4.6 Custom mappings                               *easymotion-custom-mappings*
+4.4 Custom mappings                               *easymotion-custom-mappings*
 
 EasyMotion allows you to customize all default mappings to avoid conflicts
 with existing mappings. All custom mappings follow the same variable format: >

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -18,14 +18,6 @@
 			endif
 		endfor
 	endfunction " }}}
-	function! s:InitHL(group, colors) " {{{
-		let guihl = printf('guibg=%s guifg=%s gui=%s', a:colors.gui[0], a:colors.gui[1], a:colors.gui[2])
-		let ctermhl = &t_Co == 256
-			\ ? printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm256[0], a:colors.cterm256[1], a:colors.cterm256[2])
-			\ : printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm[0], a:colors.cterm[1], a:colors.cterm[2])
-
-		execute printf('hi default %s %s %s', a:group, guihl, ctermhl)
-	endfunction " }}}
 	function! s:InitMappings(motions) "{{{
 		for motion in keys(a:motions)
 			call s:InitOptions({ 'mapping_' . motion : '<Leader>' . motion })
@@ -49,29 +41,8 @@
 		\ })
 	" }}}
 	" Default highlighting {{{
-		let s:target_hl_defaults = {
-		\   'gui'     : ['NONE', '#ff0000' , 'bold']
-		\ , 'cterm256': ['NONE', '196'     , 'bold']
-		\ , 'cterm'   : ['NONE', 'red'     , 'bold']
-		\ }
-
-		let s:shade_hl_defaults = {
-		\   'gui'     : ['NONE', '#585858' , 'NONE']
-		\ , 'cterm256': ['NONE', '240'     , 'NONE']
-		\ , 'cterm'   : ['NONE', 'darkgrey', 'NONE']
-		\ }
-
-		call s:InitHL(g:EasyMotion_target_hl, s:target_hl_defaults)
-		call s:InitHL(g:EasyMotion_shade_hl,  s:shade_hl_defaults)
-
-		" Reset highlighting after loading a new color scheme {{{
-			augroup EasyMotionInitHL
-				autocmd!
-
-				autocmd ColorScheme * call s:InitHL(g:EasyMotion_target_hl, s:target_hl_defaults)
-				autocmd ColorScheme * call s:InitHL(g:EasyMotion_shade_hl,  s:shade_hl_defaults)
-			augroup end
-		" }}}
+		hi def link EasyMotionTarget ErrorMsg
+		hi def link EasyMotionTarget LineNr
 	" }}}
 	" Default key mapping {{{
 		call s:InitMappings({


### PR DESCRIPTION
Using "hi def link" allows the user to override it how they wish (using
hi def link themselves or by setting colors directly). By hooking
ColorScheme, any user runtime changes were blown away every time it
changed.

Open to other groups for the default, these looked fine with the schemes
I tried.
