### PR TITLE
Shift the display target for JK motion before the first word character

### DIFF
--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -152,7 +152,7 @@
 		call s:EasyMotion('\(\S\(\s\|$\)\|^$\)', a:direction, a:visualmode ? visualmode() : '', mode(1))
 	endfunction " }}}
 	function! EasyMotionJK(visualmode, direction) " {{{
-		call s:EasyMotion('\%1v', a:direction, a:visualmode ? visualmode() : '', '')
+    call s:EasyMotion('^\(\w\|\s*\zs\s\|$\)', a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
 " }}}
 " Helper functions {{{


### PR DESCRIPTION
example

a
 b
  c
old behavior will display the target at the *
*
*b
- c
  new behavior
  *
  *b
  *c  (near te c rather than at the begining of the line)

Conflicts:

```
plugin/EasyMotion.vim
```
