### PR TITLE
Supported CSApprox.vim and added modeline

### DIFF
--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -587,3 +587,4 @@
 		endtry
 	endfunction " }}}
 " }}}
+" vim: foldmethod=marker:noexpandtab:ts=4:sts=4


### PR DESCRIPTION
I fixed vim-easymotion for CSApprox.vim and added modeline.
I am glad when you pull this changes.
