### PR TITLE
Fix error because EasyMotion#InitHL is undefined

### DIFF
--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -43,8 +43,8 @@
 			augroup EasyMotionInitHL
 				autocmd!
 
-				autocmd ColorScheme * call EasyMotion#InitHL(s:hl_group_target, s:target_hl_defaults)
-				autocmd ColorScheme * call EasyMotion#InitHL(s:hl_group_shade,  s:shade_hl_defaults)
+				autocmd ColorScheme * call EasyMotion#InitHL(g:EasyMotion_hl_group_target, s:target_hl_defaults)
+				autocmd ColorScheme * call EasyMotion#InitHL(g:EasyMotion_hl_group_shade,  s:shade_hl_defaults)
 			augroup end
 		" }}}
 	" }}}


### PR DESCRIPTION
Hi!

I updated this plugin version 1.3 then error occurred.
Because EasyMotion#InitHL is undefined.

So I fixed this error. But I don't get used to wrirte vim plugin.

Please check this pull request!

Thx.
