### PR TITLE
Update jumplist when moving cursor

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -456,6 +456,8 @@
 	endfunction "}}}
 	function! s:EasyMotion(regexp, direction, visualmode, mode) " {{{
 		let orig_pos = [line('.'), col('.')]
+		let orig_mark_backtick = getpos("'`")
+		normal! m`
 		let targets = []
 
 		try
@@ -544,6 +546,8 @@
 
 			" Show exception message
 			call s:Message(v:exception)
+
+			call setpos("'`", orig_mark_backtick) " Restore previous position of ` mark
 
 			" Restore original cursor position/selection {{{
 				if ! empty(a:visualmode)


### PR DESCRIPTION
EasyMotion moves the cursor using Vim's `cursor()` function, but this does not update the jumplist, which means that after jumping to a different location with EasyMotion, you can't restore the previous position with `<C-O>`.

This patch manually adds the current position to the jumplist before calling `cursor()` by setting the `'`` mark. It will restore the previous position of the mark if the EasyMotion movement is canceled.
