### PR TITLE
Autoload improvements.

### DIFF
--- a/autoload/EasyMotion/EasyMotion.vim
+++ b/autoload/EasyMotion/EasyMotion.vim
@@ -3,63 +3,8 @@
 " Author: Kim Silkebækken <kim.silkebaekken+vim@gmail.com>
 " Source repository: https://github.com/Lokaltog/vim-easymotion
 
-" Default configuration functions {{{
-	function! EasyMotion#InitOptions(options) " {{{
-		for [key, value] in items(a:options)
-			if ! exists('g:EasyMotion_' . key)
-				exec 'let g:EasyMotion_' . key . ' = ' . string(value)
-			endif
-		endfor
-	endfunction " }}}
-	function! EasyMotion#InitHL(group, colors) " {{{
-		let group_default = a:group . 'Default'
-
-		" Prepare highlighting variables
-		let guihl = printf('guibg=%s guifg=%s gui=%s', a:colors.gui[0], a:colors.gui[1], a:colors.gui[2])
-		if !exists('g:CSApprox_loaded')
-			let ctermhl = &t_Co == 256
-				\ ? printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm256[0], a:colors.cterm256[1], a:colors.cterm256[2])
-				\ : printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm[0], a:colors.cterm[1], a:colors.cterm[2])
-		else
-			let ctermhl = ''
-		endif
-
-		" Create default highlighting group
-		execute printf('hi default %s %s %s', group_default, guihl, ctermhl)
-
-		" Check if the hl group exists
-		if hlexists(a:group)
-			redir => hlstatus | exec 'silent hi ' . a:group | redir END
-
-			" Return if the group isn't cleared
-			if hlstatus !~ 'cleared'
-				return
-			endif
-		endif
-
-		" No colors are defined for this group, link to defaults
-		execute printf('hi default link %s %s', a:group, group_default)
-	endfunction " }}}
-	function! EasyMotion#InitMappings(motions) "{{{
-		for motion in keys(a:motions)
-			call EasyMotion#InitOptions({ 'mapping_' . motion : g:EasyMotion_leader_key . motion })
-		endfor
-
-		if g:EasyMotion_do_mapping
-			for [motion, fn] in items(a:motions)
-				if empty(g:EasyMotion_mapping_{motion})
-					continue
-				endif
-
-				silent exec 'nnoremap <silent> ' . g:EasyMotion_mapping_{motion} . '      :call EasyMotion#' . fn.name . '(0, ' . fn.dir . ')<CR>'
-				silent exec 'onoremap <silent> ' . g:EasyMotion_mapping_{motion} . '      :call EasyMotion#' . fn.name . '(0, ' . fn.dir . ')<CR>'
-				silent exec 'vnoremap <silent> ' . g:EasyMotion_mapping_{motion} . ' :<C-U>call EasyMotion#' . fn.name . '(1, ' . fn.dir . ')<CR>'
-			endfor
-		endif
-	endfunction "}}}
-" }}}
 " Motion functions {{{
-	function! EasyMotion#F(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#F(visualmode, direction) " {{{
 		let char = s:GetSearchChar(a:visualmode)
 
 		if empty(char)
@@ -70,7 +15,7 @@
 
 		call s:EasyMotion(re, a:direction, a:visualmode ? visualmode() : '', mode(1))
 	endfunction " }}}
-	function! EasyMotion#T(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#T(visualmode, direction) " {{{
 		let char = s:GetSearchChar(a:visualmode)
 
 		if empty(char)
@@ -85,22 +30,22 @@
 
 		call s:EasyMotion(re, a:direction, a:visualmode ? visualmode() : '', mode(1))
 	endfunction " }}}
-	function! EasyMotion#WB(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#WB(visualmode, direction) " {{{
 		call s:EasyMotion('\(\<.\|^$\)', a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
-	function! EasyMotion#WBW(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#WBW(visualmode, direction) " {{{
 		call s:EasyMotion('\(\(^\|\s\)\@<=\S\|^$\)', a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
-	function! EasyMotion#E(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#E(visualmode, direction) " {{{
 		call s:EasyMotion('\(.\>\|^$\)', a:direction, a:visualmode ? visualmode() : '', mode(1))
 	endfunction " }}}
-	function! EasyMotion#EW(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#EW(visualmode, direction) " {{{
 		call s:EasyMotion('\(\S\(\s\|$\)\|^$\)', a:direction, a:visualmode ? visualmode() : '', mode(1))
 	endfunction " }}}
-	function! EasyMotion#JK(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#JK(visualmode, direction) " {{{
 		call s:EasyMotion('^\(\w\|\s*\zs\|$\)', a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
-	function! EasyMotion#Search(visualmode, direction) " {{{
+	function! EasyMotion#EasyMotion#Search(visualmode, direction) " {{{
 		call s:EasyMotion(@/, a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
 " }}}

--- a/autoload/EasyMotion/Init.vim
+++ b/autoload/EasyMotion/Init.vim
@@ -1,0 +1,62 @@
+" EasyMotion - Vim motions on speed!
+"
+" Author: Kim Silkebækken <kim.silkebaekken+vim@gmail.com>
+" Source repository: https://github.com/Lokaltog/vim-easymotion
+
+" Default configuration functions {{{
+	function! EasyMotion#Init#InitOptions(options) " {{{
+		for [key, value] in items(a:options)
+			if ! exists('g:EasyMotion_' . key)
+				exec 'let g:EasyMotion_' . key . ' = ' . string(value)
+			endif
+		endfor
+	endfunction " }}}
+	function! EasyMotion#Init#InitHL(group, colors) " {{{
+		let group_default = a:group . 'Default'
+
+		" Prepare highlighting variables
+		let guihl = printf('guibg=%s guifg=%s gui=%s', a:colors.gui[0], a:colors.gui[1], a:colors.gui[2])
+		if !exists('g:CSApprox_loaded')
+			let ctermhl = &t_Co == 256
+				\ ? printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm256[0], a:colors.cterm256[1], a:colors.cterm256[2])
+				\ : printf('ctermbg=%s ctermfg=%s cterm=%s', a:colors.cterm[0], a:colors.cterm[1], a:colors.cterm[2])
+		else
+			let ctermhl = ''
+		endif
+
+		" Create default highlighting group
+		execute printf('hi default %s %s %s', group_default, guihl, ctermhl)
+
+		" Check if the hl group exists
+		if hlexists(a:group)
+			redir => hlstatus | exec 'silent hi ' . a:group | redir END
+
+			" Return if the group isn't cleared
+			if hlstatus !~ 'cleared'
+				return
+			endif
+		endif
+
+		" No colors are defined for this group, link to defaults
+		execute printf('hi default link %s %s', a:group, group_default)
+	endfunction " }}}
+	function! EasyMotion#Init#InitMappings(motions) "{{{
+		for motion in keys(a:motions)
+			call EasyMotion#Init#InitOptions({ 'mapping_' . motion : g:EasyMotion_leader_key . motion })
+		endfor
+
+		if g:EasyMotion_do_mapping
+			for [motion, fn] in items(a:motions)
+				if empty(g:EasyMotion_mapping_{motion})
+					continue
+				endif
+
+				silent exec 'nnoremap <silent> ' . g:EasyMotion_mapping_{motion} . '      :call EasyMotion#EasyMotion#' . fn.name . '(0, ' . fn.dir . ')<CR>'
+				silent exec 'onoremap <silent> ' . g:EasyMotion_mapping_{motion} . '      :call EasyMotion#EasyMotion#' . fn.name . '(0, ' . fn.dir . ')<CR>'
+				silent exec 'vnoremap <silent> ' . g:EasyMotion_mapping_{motion} . ' :<C-U>call EasyMotion#EasyMotion#' . fn.name . '(1, ' . fn.dir . ')<CR>'
+			endfor
+		endif
+	endfunction "}}}
+" }}}
+
+" vim: fdm=marker:noet:ts=4:sw=4:sts=4

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -12,7 +12,7 @@
 " }}}
 " Default configuration {{{
 	" Default options {{{
-		call EasyMotion#InitOptions({
+		call EasyMotion#Init#InitOptions({
 		\   'leader_key'      : '<Leader><Leader>'
 		\ , 'keys'            : 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 		\ , 'do_shade'        : 1
@@ -36,20 +36,20 @@
 		\ , 'cterm'   : ['NONE', 'grey'    , 'NONE']
 		\ }
 
-		call EasyMotion#InitHL(g:EasyMotion_hl_group_target, s:target_hl_defaults)
-		call EasyMotion#InitHL(g:EasyMotion_hl_group_shade,  s:shade_hl_defaults)
+		call EasyMotion#Init#InitHL(g:EasyMotion_hl_group_target, s:target_hl_defaults)
+		call EasyMotion#Init#InitHL(g:EasyMotion_hl_group_shade,  s:shade_hl_defaults)
 
 		" Reset highlighting after loading a new color scheme {{{
 			augroup EasyMotionInitHL
 				autocmd!
 
-				autocmd ColorScheme * call EasyMotion#InitHL(g:EasyMotion_hl_group_target, s:target_hl_defaults)
-				autocmd ColorScheme * call EasyMotion#InitHL(g:EasyMotion_hl_group_shade,  s:shade_hl_defaults)
+				autocmd ColorScheme * call EasyMotion#Init#InitHL(g:EasyMotion_hl_group_target, s:target_hl_defaults)
+				autocmd ColorScheme * call EasyMotion#Init#InitHL(g:EasyMotion_hl_group_shade,  s:shade_hl_defaults)
 			augroup end
 		" }}}
 	" }}}
 	" Default key mapping {{{
-		call EasyMotion#InitMappings({
+		call EasyMotion#Init#InitMappings({
 		\   'f' : { 'name': 'F'  , 'dir': 0 }
 		\ , 'F' : { 'name': 'F'  , 'dir': 1 }
 		\ , 't' : { 'name': 'T'  , 'dir': 0 }


### PR DESCRIPTION
Refactored autoload into two files to make proper use of autoload advantages.

Autoload is useful as it saves having to load too much code on startup.
However, calling the functions in the autoload/ file from the plugin/ file
results in the load-on-startup happening anyway, so it might as well be in
plugin/.  This patch splits the autoload code into two files:
- EasyMotion/Init.vim for the stuff that's loaded on startup and
- EasyMotion/EasyMotion.vim for the stuff that's loaded on demand.
