### PR TITLE
Use double-key combos which are much faster to type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Jeffrey Way of Nettuts+ has also [written
 a tutorial](http://net.tutsplus.com/tutorials/other/vim-essential-plugin-easymotion/)
 about EasyMotion.
 
+## Two Character Combos
+
+Two character combo support was added by Yan Pritzker (@skwp). This changes the
+default behavior of EasyMotion to highlight everything with a two-key combo. This
+makes it possible to immediately reach any location without going through multiple
+rounds of typing and looking, making usage much faster. This change is currently
+available only on the @skwp fork of easy motion. It is not currently possible 
+to disable this behavior.
+
 ## Animated demonstration
 
 ![Animated demonstration](http://oi54.tinypic.com/2yysefm.jpg)


### PR DESCRIPTION
Alpha support, not fully tested with all EasyMotion type commands
but works with ,,w and ,,b for sure. Appears to calculate
targets a little aggressively (sometimes multiple targets per word)

![screenshot](http://i.imgur.com/uoCdP.png)
