### PR TITLE
Integration with Vim jumps

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -535,8 +535,10 @@
 
 			" Update cursor position
 			call cursor(orig_pos[0], orig_pos[1])
-			mark '
-			call cursor(coords[0], coords[1])
+			let mark_save = getpos("'e")
+			call setpos("'e", [bufnr('%'), coords[0], coords[1], 0])
+			execute 'normal! `e'
+			call setpos("'e", mark_save)
 
 			call s:Message('Jumping to [' . coords[0] . ', ' . coords[1] . ']')
 		catch


### PR DESCRIPTION
Hi,

This pull request enables EasyMotion movements to trigger [jumps](http://vimdoc.sourceforge.net/htmldoc/motion.html#:jumps).

Currently, EasyMotion only sets the `'` mark without remembering the column the cursor was in before moving. With this update, the `'` mark is still set (now taking the cursor column into account). Moreover, these movements are now integrated into Vim's jump history: you can go back/forward to these cursor positions using `<c-o>` and `<c-i>`.
