### PR TITLE
Add sentence and paragraph movements

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -103,6 +103,12 @@
 	function! EasyMotion#Search(visualmode, direction) " {{{
 		call s:EasyMotion(@/, a:direction, a:visualmode ? visualmode() : '', '')
 	endfunction " }}}
+	function! EasyMotion#Sentence(visualmode, direction) " {{{
+		call s:EasyMotion('\(\%^\|\n\s*\n\|[.!?][])''"]*\s\+\)\zs', a:direction, a:visualmode ? visualmode() : '', '')
+	endfunction " }}}
+	function! EasyMotion#Paragraph(visualmode, direction) " {{{
+		call s:EasyMotion('\(\%^\|\n\s*\n\)\zs', a:direction, a:visualmode ? visualmode() : '', '')
+	endfunction " }}}
 " }}}
 " Helper functions {{{
 	function! s:Message(message) " {{{

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -97,6 +97,10 @@ visual and operator-pending mode:
     <Leader>k         | Line upward. See |k|.
     <Leader>n         | Jump to latest "/" or "?" forward. See |n|.
     <Leader>N         | Jump to latest "/" or "?" backward. See |N|.
+    <Leader>s         | Beginning of sentence forward. See |(|.
+    <Leader>S         | Beginning of sentence backward. See |)|.
+    <Leader>p         | Beginning of paragraph forward. See |{|.
+    <Leader>P         | Beginning of paragraph backward. See |}|.
 
 See |easymotion-leader-key| and |mapleader| for details about the leader key.
 See |easymotion-custom-mappings| for customizing the default mappings.

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -66,6 +66,10 @@
 		\ , 'k' : { 'name': 'JK' , 'dir': 1 }
 		\ , 'n' : { 'name': 'Search' , 'dir': 0 }
 		\ , 'N' : { 'name': 'Search' , 'dir': 1 }
+		\ , 's' : { 'name': 'Sentence' , 'dir': 0 }
+		\ , 'S' : { 'name': 'Sentence' , 'dir': 1 }
+		\ , 'p' : { 'name': 'Paragraph' , 'dir': 0 }
+		\ , 'P' : { 'name': 'Paragraph' , 'dir': 1 }
 		\ })
 	" }}}
 " }}}


### PR DESCRIPTION
This commit adds the `s`, `S`, `p`, and `P` motions, which allow movement between sentences and paragraphs based on Vim's built-in `(`, `)`, `{`, and `}` motions.
