### PR TITLE
Break undo history

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -143,6 +143,8 @@
 		for [line_num, line] in a:lines
 			call setline(line_num, line[a:key])
 		endfor
+		" Break undo history
+		let &undolevels = &undolevels
 	endfunction " }}}
 	function! s:GetChar() " {{{
 		let char = getchar()


### PR DESCRIPTION
Make undo behavior after using easymotion in operator pending mode
consistent with Vim's default behavior

Problem and how to reproduce:
1. `exec normal! "i{text}<C-[>"` or something
2. `d<Leader><Leader>s{target}`
3. type `u`

In this case, undo should restore second operation only, but it restored
first operation in addition to second one because undojoin command is
called in SetLines() function.

Solution: break undo  history by `let &undolevels = &undolevels` 
See:  :h undojoin

This commit fix this problem.
