### PR TITLE
Updates requirements to vim 7.3

### DIFF
--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -603,13 +603,14 @@ See |easymotion-leader-key| and |mapleader| for details about the leader key.
 ==============================================================================
 Requirements                                          *easymotion-requirements*
 
-EasyMotion has been developed and tested in vim 7.3, but it should run without
-any problems in vim 7.2.
+EasyMotion needs at least vim 7.3 to run without problems.
+Active development and testing is done with vim 7.4 since the 2.0 release of
+EasyMotion.
 
 Vi-compatible mode must be disabled.
 
-Note: Now @haya14busa maintain EasyMotion in vim 7.4. If there is any
-problems, open an issue or pull requests are welcome.
+If there are any problems due to the vim version you use, feel free to open
+an issue on github!
 
 https://github.com/haya14busa/vim-easymotion/issues
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -8,7 +8,7 @@
 if expand("%:p") ==# expand("<sfile>:p")
   unlet! g:EasyMotion_loaded
 endif
-if exists('g:EasyMotion_loaded') || &compatible || version < 702
+if exists('g:EasyMotion_loaded') || &compatible || version < 703
     finish
 endif
 


### PR DESCRIPTION
You're using functions that where introduced with 7.3 such as `strdisplaywidth()`. I updated the requirements, if you don't mind.

Closes #91.
