### PR TITLE
Do not match newlines in `highlight` output

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -384,7 +384,9 @@ function! s:turn_off_hl_error() "{{{
         finally
             let &verbose = save_verbose
         endtry
-        let hl = substitute(matchstr(cursor, 'xxx \zs.*'), '[ \t\n]\+\|cleared', ' ', 'g')
+        " NOTE: do not match across newlines, to remove 'links to Foo'
+        " (https://github.com/Lokaltog/vim-easymotion/issues/95)
+        let hl = substitute(matchstr(cursor, 'xxx \zs[^\n]*'), '[ \t\n]\+\|cleared', ' ', 'g')
         if !empty(substitute(hl, '\s', '', 'g'))
             let s:old_hl_error = hl
         endif

--- a/autoload/vital/_easymotion/Over/Commandline.vim
+++ b/autoload/vital/_easymotion/Over/Commandline.vim
@@ -262,7 +262,9 @@ function! s:base.hl_cursor_off()
 		finally
 			let &verbose = save_verbose
 		endtry
-		let hl = substitute(matchstr(cursor, 'xxx \zs.*'), '[ \t\n]\+\|cleared', ' ', 'g')
+		" NOTE: do not match across newlines, to remove 'links to Foo'
+		" (https://github.com/osyo-manga/vital-over/issues/23)
+		let hl = substitute(matchstr(cursor, 'xxx \zs[^\n]*'), '[ \t\n]\+\|cleared', ' ', 'g')
 		if !empty(substitute(hl, '\s', '', 'g'))
 			let self.variables.old_hi_cursor = hl
 		endif


### PR DESCRIPTION
This is a quick fix for https://github.com/Lokaltog/vim-easymotion/issues/95.

Without this, `links to Foo` might be included, which results in an
error, when throwing that into a call to `highlight` to restore it.

The proper fix would be to restore it as `highlight link Cursor|Error
FooLink`, but that requires refactoring, since the return value for
`hl_cursor_off`/`turn_off_hl_error` is used as a definition also.

Fixes https://github.com/osyo-manga/vital-over/issues/23
Fixes https://github.com/Lokaltog/vim-easymotion/issues/95
