### PR TITLE
make `EasyMotion#WB` and `EasyMotion#E` be consistent with vim's `iskeyword`

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -160,6 +160,12 @@ function! EasyMotion#WBW(visualmode, direction) " {{{
     call s:EasyMotion('\(\(^\|\s\)\@<=\S\|^$\)', a:direction, a:visualmode ? visualmode() : '', 0)
     return s:EasyMotion_is_cancelled
 endfunction " }}}
+function! EasyMotion#WBK(visualmode, direction) " {{{
+    " vim's iskeyword style word motion
+    let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
+    call s:EasyMotion('\(\(\<\|\>\|\s\)\@<=\S\|^$\)', a:direction, a:visualmode ? visualmode() : '', 0)
+    return s:EasyMotion_is_cancelled
+endfunction " }}}
 function! EasyMotion#E(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     let is_inclusive = mode(1) ==# 'no' ? 1 : 0
@@ -170,6 +176,13 @@ function! EasyMotion#EW(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     let is_inclusive = mode(1) ==# 'no' ? 1 : 0
     call s:EasyMotion('\(\S\(\s\|$\)\|^$\)', a:direction, a:visualmode ? visualmode() : '', is_inclusive)
+    return s:EasyMotion_is_cancelled
+endfunction " }}}
+function! EasyMotion#EK(visualmode, direction) " {{{
+    " vim's iskeyword style word motion
+    let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
+    let is_inclusive = mode(1) ==# 'no' ? 1 : 0
+    call s:EasyMotion('\(\S\(\>\|\<\|\s\)\@=\|^$\)', a:direction, a:visualmode ? visualmode() : '', is_inclusive)
     return s:EasyMotion_is_cancelled
 endfunction " }}}
 " -- JK Motion ---------------------------

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -136,6 +136,15 @@ noremap  <silent><Plug>(easymotion-bd-W)      :<C-u>call EasyMotion#WBW(0,2)<CR>
 xnoremap <silent><Plug>(easymotion-bd-W) <Esc>:<C-u>call EasyMotion#WBW(1,2)<CR>
 "}}}
 
+" iskeyword {{{
+noremap  <silent><Plug>(easymotion-iskeyword-w)         :<C-u>call EasyMotion#WBK(0,0)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-w)    <Esc>:<C-u>call EasyMotion#WBK(1,0)<CR>
+noremap  <silent><Plug>(easymotion-iskeyword-b)         :<C-u>call EasyMotion#WBK(0,1)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-b)    <Esc>:<C-u>call EasyMotion#WBK(1,1)<CR>
+noremap  <silent><Plug>(easymotion-iskeyword-bd-w)      :<C-u>call EasyMotion#WBK(0,2)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-bd-w) <Esc>:<C-u>call EasyMotion#WBK(1,2)<CR>
+" }}}
+
 " End Word: {{{
 noremap  <silent><Plug>(easymotion-e)         :<C-u>call EasyMotion#E(0,0)<CR>
 xnoremap <silent><Plug>(easymotion-e)    <Esc>:<C-u>call EasyMotion#E(1,0)<CR>
@@ -152,6 +161,15 @@ noremap  <silent><Plug>(easymotion-gE)        :<C-u>call EasyMotion#EW(0,1)<CR>
 xnoremap <silent><Plug>(easymotion-gE)   <Esc>:<C-u>call EasyMotion#EW(1,1)<CR>
 noremap  <silent><Plug>(easymotion-bd-E)      :<C-u>call EasyMotion#EW(0,2)<CR>
 xnoremap <silent><Plug>(easymotion-bd-E) <Esc>:<C-u>call EasyMotion#EW(1,2)<CR>
+"}}}
+
+" iskeyword End: {{{
+noremap  <silent><Plug>(easymotion-iskeyword-e)         :<C-u>call EasyMotion#EK(0,0)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-e)    <Esc>:<C-u>call EasyMotion#EK(1,0)<CR>
+noremap  <silent><Plug>(easymotion-iskeyword-ge)        :<C-u>call EasyMotion#EK(0,1)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-ge)   <Esc>:<C-u>call EasyMotion#EK(1,1)<CR>
+noremap  <silent><Plug>(easymotion-iskeyword-bd-e)      :<C-u>call EasyMotion#EK(0,2)<CR>
+xnoremap <silent><Plug>(easymotion-iskeyword-bd-e) <Esc>:<C-u>call EasyMotion#EK(1,2)<CR>
 "}}}
 "}}}
 


### PR DESCRIPTION
Make function `EasyMotion#WB` and `EasyMotion#E` be consistent with vim's `iskeyword` option.

@haya14busa
It matches a little bit much, especially combined with the two-key highlighting feature. Perhaps we can solve this problem by providing a config option to let the users decide what they want, the consistence or the two-key highlighting, or both.
