### PR TITLE
Within line motion 時の shade の範囲の変更

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1258,13 +1258,25 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive) " {{{
         if g:EasyMotion_do_shade && targets_len != 1 && s:flag.dot_repeat != 1
             if a:direction == 1
                 " Backward
-                let shade_hl_re = '\%'. win_first_line .'l\_.*\%#'
+                if s:flag.within_line
+                    let shade_hl_re = '^.*\%#'
+                else
+                    let shade_hl_re = '\%'. win_first_line .'l\_.*\%#'
+                endif
             elseif a:direction == 0
                 " Forward
-                let shade_hl_re = '\%#\_.*\%'. win_last_line .'l'
+                if s:flag.within_line
+                    let shade_hl_re = '\%#.*$'
+                else
+                    let shade_hl_re = '\%#\_.*\%'. win_last_line .'l'
+                endif
             else
                 " Both directions"
-                let shade_hl_re = '\_.*'
+                if s:flag.within_line
+                    let shade_hl_re = '^.*\%#.*$'
+                else
+                    let shade_hl_re = '\_.*'
+                endif
             endif
 
             call EasyMotion#highlight#add_highlight(


### PR DESCRIPTION
`<Plug>(easymotion-fl)`をした時
![before](https://cloud.githubusercontent.com/assets/6252452/2750319/c33f3d3a-c869-11e3-9039-9fa7ff438cd2.png)
が
![after](https://cloud.githubusercontent.com/assets/6252452/2750323/cebe19d8-c869-11e3-84a1-9e70c0a6a209.png)
こうなる様にした。
