### PR TITLE
Put motion character f and j in normal order

### DIFF
--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -23,7 +23,7 @@ set cpo&vim
 " == Default configuration {{{
 " -- Option ------------------------------ {{{
 let g:EasyMotion_keys               = get(g:,
-    \ 'EasyMotion_keys', 'asdghklqwertyuiopzxcvbnmfj;')
+    \ 'EasyMotion_keys', 'asdfghjklqwertyuiopzxcvbnm;')
     " \ 'EasyMotion_keys', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
 let g:EasyMotion_do_mapping         = get(g: , 'EasyMotion_do_mapping'         , 1)
 let g:EasyMotion_do_shade           = get(g: , 'EasyMotion_do_shade'           , 1)


### PR DESCRIPTION
Currently keys f and j are put near the end of target one key sequence, this makes the usage non-intuitive.
