### PR TITLE
Introduce verbose option

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -53,7 +53,6 @@ function! EasyMotion#init()
     let s:EasyMotion_is_cancelled = 0
     " 0 -> Success
     " 1 -> Cancel
-    let g:EasyMotion_ignore_exception = 0
     return ""
 endfunction
 "}}}
@@ -405,11 +404,7 @@ function! s:Prompt(message) " {{{
     echohl None
 endfunction " }}}
 function! s:Throw(message) "{{{
-    if g:EasyMotion_verbose
-        throw 'EasyMotion: ' . a:message
-    else
-        throw
-    endif
+    throw 'EasyMotion: ' . a:message
 endfunction "}}}
 
 " -- Save & Restore values ---------------
@@ -1527,7 +1522,7 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
         redraw
 
         " Show exception message
-        if g:EasyMotion_ignore_exception != 1
+        if g:EasyMotion_verbose == 1
             echo v:exception
         endif
 

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -53,6 +53,7 @@ function! EasyMotion#init()
     let s:EasyMotion_is_cancelled = 0
     " 0 -> Success
     " 1 -> Cancel
+    let g:EasyMotion_ignore_exception = 0
     return ""
 endfunction
 "}}}
@@ -1522,7 +1523,8 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
         redraw
 
         " Show exception message
-        if g:EasyMotion_verbose == 1
+        " The verbose option will take precedence
+        if g:EasyMotion_verbose == 1 && g:EasyMotion_ignore_exception != 1
             echo v:exception
         endif
 

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -391,7 +391,13 @@ endfunction " }}}
 " Helper Functions: {{{
 " -- Message -----------------------------
 function! s:Message(message) " {{{
-    echo 'EasyMotion: ' . a:message
+    if g:EasyMotion_verbose
+        echo 'EasyMotion: ' . a:message
+    else
+        " Make the current message dissapear
+        echo ''
+        " redraw
+    endif
 endfunction " }}}
 function! s:Prompt(message) " {{{
     echohl Question
@@ -399,7 +405,11 @@ function! s:Prompt(message) " {{{
     echohl None
 endfunction " }}}
 function! s:Throw(message) "{{{
-    throw 'EasyMotion: ' . a:message
+    if g:EasyMotion_verbose
+        throw 'EasyMotion: ' . a:message
+    else
+        throw
+    endif
 endfunction "}}}
 
 " -- Save & Restore values ---------------

--- a/autoload/EasyMotion/command_line.vim
+++ b/autoload/EasyMotion/command_line.vim
@@ -206,7 +206,9 @@ function! s:Cancell() " {{{
     call EasyMotion#highlight#delete_highlight()
     call EasyMotion#helper#VarReset('&scrolloff')
     keepjumps call setpos('.', s:save_orig_pos)
-    echo 'EasyMotion: Cancelled'
+    if g:EasyMotion_verbose
+        echo 'EasyMotion: Cancelled'
+    endif
     return ''
 endfunction " }}}
 function! s:getPromptMessage(num_strokes) "{{{

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -33,6 +33,7 @@ CONTENTS                                                 *easymotion-contents*
        EasyMotion_add_search_history ... |EasyMotion_add_search_history|
        EasyMotion_off_screen_search .... |EasyMotion_off_screen_search|
        EasyMotion_disable_two_key_combo. |EasyMotion_disable_two_key_combo|
+       EasyMotion_verbose .............. |EasyMotion_verbose|
        Custom highlighting ............. |easymotion-custom-hl|
        Custom mappings ................. |easymotion-custom-mappings|
            Leader key .................. |easymotion-leader-key|
@@ -937,6 +938,16 @@ EasyMotion_disable_two_key_combo           *g:EasyMotion_disable_two_key_combo*
     let g:EasyMotion_disable_two_key_combo = 1
 <
     Default: 0
+
+EasyMotion_verbose                       *g:EasyMotion_verbose*
+
+    If you set this option to 0, you can disable all the messages the plugin
+    creates, such as "EasyMotion: Jumping to [l,c]" and "EasyMotion:
+    Cancelled".
+>
+    let g:EasyMotion_verbose = 0
+<
+    Default: 1
 
 ------------------------------------------------------------------------------
 Custom highlighting                                      *easymotion-custom-hl*

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -44,6 +44,7 @@ let g:EasyMotion_add_search_history = get(g: , 'EasyMotion_add_search_history' ,
 let g:EasyMotion_off_screen_search  = get(g: , 'EasyMotion_off_screen_search'  , 1)
 let g:EasyMotion_force_csapprox     = get(g: , 'EasyMotion_force_csapprox'     , 0)
 let g:EasyMotion_show_prompt        = get(g: , 'EasyMotion_show_prompt'        , 1)
+let g:EasyMotion_verbose            = get(g: , 'EasyMotion_verbose'            , 1)
 let g:EasyMotion_prompt             =
     \ get(g: , 'EasyMotion_prompt' , 'Search for {n} character(s): ')
 let g:EasyMotion_command_line_key_mappings =

--- a/t/easymotion_spec.vim
+++ b/t/easymotion_spec.vim
@@ -1432,6 +1432,40 @@ describe 'Word motion'
     end
     "}}}
 end
+
+describe 'Verbose'
+    before
+        new
+        map s <Plug>(easymotion-s)
+        map f <Plug>(easymotion-f)
+        map F <Plug>(easymotion-F)
+        map t <Plug>(easymotion-t)
+        map T <Plug>(easymotion-T)
+        call EasyMotion#init()
+        call AddLine('some words in the sentence')
+    end
+
+    after
+        close!
+    end
+
+    it 'Verbose global variable'
+        Expect g:EasyMotion_verbose ==# 1
+    end
+
+    it 'Turned On'
+        let g:EasyMotion_verbose = 1
+        let &verbosefile = tempname()
+        normal sa
+        " TODO: l:tmp_name_verbose should have one line
+    end
+    it 'Turned Off'
+        let g:EasyMotion_verbose = 0
+        let &verbosefile = &verbosefile
+        normal s_
+        " TODO: l:tmp_name_not_verbose should have no lines
+    end
+end
 "}}}
 
 " vim: fdm=marker:et:ts=4:sw=4:sts=4


### PR DESCRIPTION
Provide a way to silence nagging messages, more appropriate for a debug
situation.
You can define `let g:EasyMotion_verbose = 0` to quiet most messages. By default, the variable is set to 1 to maintain the current behaviour.

This is similar to PR #239, but more aggressive, silences a lot more stuff by going directly to the source.