### PR TITLE
Add `h` and `l`, like `j` and `k`

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -211,6 +211,13 @@ function! EasyMotion#JK(visualmode, direction) " {{{
     endif
     return s:EasyMotion_is_cancelled
 endfunction " }}}
+function! EasyMotion#HL(visualmode, direction) " {{{
+    let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
+    let s:flag.linewise = 1
+    let s:flag.within_line = 1
+    call s:EasyMotion('.', a:direction, a:visualmode ? visualmode() : '', 0)
+    return s:EasyMotion_is_cancelled
+endfunction " }}}
 function! EasyMotion#Sol(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     let s:flag.linewise = 1

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -198,6 +198,8 @@ call s:motion_map_helper({
     \ 'lineforward'     : {'fnc' : 'LineAnywhere', 'direction': 0},
     \ 'linebackward'    : {'fnc' : 'LineAnywhere', 'direction': 1},
     \ 'lineanywhere'    : {'fnc' : 'LineAnywhere', 'direction': 2},
+    \ 'h'               : {'fnc' : 'HL', 'direction': 1},
+    \ 'l'               : {'fnc' : 'HL', 'direction': 0},
     \ })
 "}}}
 
@@ -261,6 +263,7 @@ if g:EasyMotion_do_mapping == 1
     call s:default_mapping(
         \ ['f', 'F', 's', 't', 'T',
         \  'w', 'W', 'b', 'B', 'e', 'E', 'ge', 'gE',
+        \  'h', 'l',
         \  'j', 'k', 'n', 'N'], g:EasyMotion_do_mapping)
 endif "}}}
 


### PR DESCRIPTION
**vim-easymotion** makes me move faster in Vim, by a familiar way, like `j`, `k`, `w`, and so on.

However, `h` and `l` is not included, which should be as important as `j` and `k`.

In the [hjkl motions](https://github.com/easymotion/vim-easymotion#hjkl-motions), an operation of `h` and `l` is introduced. I don't think it's good, because I will use `b` and `w` instead in such cases.

In Vim, `h` or `l` moves by character, `j` or `k` moves by line. In **vim-easymotion**, `j` and `k` can jump to any line on the screen, so `h` and `l` should jump to any character in the line, by default. That's more intuitive!

The *word* of Vim is too long in some language, such as CJK. I need **vim-easymotion** to help me move faster in a long *word*.

In fact, [Migemo](https://github.com/easymotion/vim-easymotion#migemo-feature-for-japanese-user) is a good solution, but not works for me, because I use Chinese. Before it is improved with great efforts to support all the languages, I think an intuitive `h` and `l` is good.
