### PR TITLE
Preserve scrolloff variable

### DIFF
--- a/autoload/EasyMotion/command_line.vim
+++ b/autoload/EasyMotion/command_line.vim
@@ -150,6 +150,7 @@ endfunction "}}}
 function! s:search.on_leave(cmdline) "{{{
     if s:num_strokes == -1
         call EasyMotion#highlight#delete_highlight(g:EasyMotion_hl_inc_search)
+        call EasyMotion#helper#VarReset('&scrolloff')
     endif
 endfunction "}}}
 function! s:search.on_char(cmdline) "{{{


### PR DESCRIPTION
When searching, there's a missing VarReset.

Otherwise, when using the search feature (_easymotion-s_) the variable is stored but never restored.
