### PR TITLE
added EasyMotion#Regex

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1558,6 +1558,10 @@ endfunction " }}}
 "}}}
 " }}}
 
+function! EasyMotion#Regex(reg)
+    call s:EasyMotion(a:reg, 2, '', 0)
+endfunction
+
 call EasyMotion#init()
 " Restore 'cpoptions' {{{
 let &cpo = s:save_cpo


### PR DESCRIPTION
This is a very small simply function. It takes a regex as it's only argument and
then directly calls s:EasyMotion as a bidirectional search. It can't be (to the
best of my knowledge) added as a regular <Plug> because it takes an argument.
But it can be called directly or mapped with a specific regex.

The idea is to allow users to map commonly used patterns to avoid repeatedly
typing the same regex patterns. One personal use that I found very helpful is to
include it as an autocommand in my manpages mapped to:

  nmap <buffer> F call EasyMotion#Regex('\w\+(\d)')

This allows me to quickly find other manpage references to jump to. I am unsure
of the protocol in regards to the documentation. Whether I should make the changes
or of you'd rather do it yourself if you decide to accept this request. If you
like what I've done and want me to update the docs and/or readme, just let me
know.

Thanks for your consideration and I hope you like what I've done.