### PR TITLE
Change of iskeyword-regexes and test file for motions

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -181,8 +181,8 @@ function! EasyMotion#WB(visualmode, direction) " {{{
 endfunction " }}}
 function! EasyMotion#WBW(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
-    let l:regex_without_file_ends = '\v(^|\s)\zs\S|^$'
-    let l:regex = l:regex_without_file_ends
+    let regex_without_file_ends = '\v(^|\s)\zs\S|^$'
+    let regex = l:regex_without_file_ends
                 \ . (a:direction == 1 ? '' : '|%$')
                 \ . (a:direction == 0 ? '' : '|%^')
     call s:EasyMotion(l:regex, a:direction, a:visualmode ? visualmode() : '', 0)
@@ -191,8 +191,8 @@ endfunction " }}}
 function! EasyMotion#WBK(visualmode, direction) " {{{
     " vim's iskeyword style word motion
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
-    let l:regex_without_file_ends = '\v<|^\S|\s\zs\S|>\zs\S|^$'
-    let l:regex = l:regex_without_file_ends
+    let regex_without_file_ends = '\v<|^\S|\s\zs\S|>\zs\S|^$'
+    let regex = l:regex_without_file_ends
                 \ . (a:direction == 1 ? '' : '|%$')
                 \ . (a:direction == 0 ? '' : '|%^')
     call s:EasyMotion(l:regex, a:direction, a:visualmode ? visualmode() : '', 0)
@@ -210,8 +210,8 @@ function! EasyMotion#EW(visualmode, direction) " {{{
     " Note: The stopping positions for 'E' and 'gE' differs. Thus, the regex
     " for direction==2 cannot be the same in both directions. This will be
     " ignored.
-    let l:regex_stub = '\v\S(\s|$)'
-    let l:regex = l:regex_stub
+    let regex_stub = '\v\S(\s|$)'
+    let regex = l:regex_stub
                 \ . (a:direction == 0 ? '' : '|^$|%^')
                 \ . (a:direction == 1 ? '' : '|%$')
     call s:EasyMotion(l:regex, a:direction, a:visualmode ? visualmode() : '', 0)
@@ -224,8 +224,8 @@ function! EasyMotion#EK(visualmode, direction) " {{{
     " Note: The stopping positions for 'e' and 'ge' differs. Thus, the regex
     " for direction==2 cannot be the same in both directions. This will be
     " ignored.
-    let l:regex_stub = '\v.\ze>|\S\ze\s*$|\S\ze\s|\k\zs>\S\ze|\S<'
-    let l:regex = l:regex_stub
+    let regex_stub = '\v.\ze>|\S\ze\s*$|\S\ze\s|\k\zs>\S\ze|\S<'
+    let regex = l:regex_stub
                 \ . (a:direction == 0 ? '' : '|^$|%^')
                 \ . (a:direction == 1 ? '' : '|%$')
     call s:EasyMotion(l:regex, a:direction, a:visualmode ? visualmode() : '', 0)

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -181,7 +181,6 @@ function! EasyMotion#WB(visualmode, direction) " {{{
 endfunction " }}}
 function! EasyMotion#WBW(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
-    " Note: Previous regex for all directions was '\(\(^\|\s\)\@<=\S\|^$\)'
     let l:regex_without_file_ends = '\v(^|\s)\zs\S|^$'
     let l:regex = l:regex_without_file_ends
                 \ . (a:direction == 1 ? '' : '|%$')
@@ -192,7 +191,6 @@ endfunction " }}}
 function! EasyMotion#WBK(visualmode, direction) " {{{
     " vim's iskeyword style word motion
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
-    " Note: Previous regex for all directions was '\(\(\<\|\>\|\s\)\@<=\S\|^$\)'
     let l:regex_without_file_ends = '\v<|^\S|\s\zs\S|>\zs\S|^$'
     let l:regex = l:regex_without_file_ends
                 \ . (a:direction == 1 ? '' : '|%$')
@@ -209,7 +207,6 @@ endfunction " }}}
 function! EasyMotion#EW(visualmode, direction) " {{{
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     let is_inclusive = mode(1) ==# 'no' ? 1 : 0
-    " Note: Previous regex for all directions was '\(\S\(\s\|$\)\|^$\)'
     " Note: The stopping positions for 'E' and 'gE' differs. Thus, the regex
     " for direction==2 cannot be the same in both directions. This will be
     " ignored.
@@ -224,7 +221,6 @@ function! EasyMotion#EK(visualmode, direction) " {{{
     " vim's iskeyword style word motion
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     let is_inclusive = mode(1) ==# 'no' ? 1 : 0
-    " Note: Previous regex for all directions was '\(\S\(\>\|\<\|\s\)\@=\|^$\)'
     " Note: The stopping positions for 'e' and 'ge' differs. Thus, the regex
     " for direction==2 cannot be the same in both directions. This will be
     " ignored.

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1308,8 +1308,7 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
         "       but in this case, it's better to allows jump side effect
         "       to gathering matched targets coordinates.
         let pos = searchpos(regexp, search_direction . (config.accept_cursor_pos ? 'c' : ''), search_stopline)
-        let num_jumpmarks = 0
-        while l:num_jumpmarks < g:EasyMotion_maximal_jumpmarks
+        while 1
             " Reached end of search range
             if pos == [0, 0]
                 break
@@ -1328,7 +1327,6 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
             endif
             "}}}
             let pos = searchpos(regexp, search_direction, search_stopline)
-            let l:num_jumpmarks += 1
         endwhile
         "}}}
 
@@ -1346,17 +1344,15 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
             keepjumps call cursor(s:current.cursor_position[0],
                                 \ s:current.cursor_position[1])
 
-            let l:num_jumpmarks = 0
             let targets2 = []
             if s:flag.within_line == 0
                 let search_stopline = win_first_line
             else
                 let search_stopline = s:current.cursor_position[0]
             endif
-            while l:num_jumpmarks < g:EasyMotion_maximal_jumpmarks
+            while 1
                 " TODO: refactoring
                 let pos = searchpos(regexp, 'b', search_stopline)
-                let l:num_jumpmarks += 1
                 " Reached end of search range
                 if pos == [0, 0]
                     break

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -187,7 +187,12 @@ endfunction " }}}
 function! EasyMotion#WBK(visualmode, direction) " {{{
     " vim's iskeyword style word motion
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
-    call s:EasyMotion('\(\(\<\|\>\|\s\)\@<=\S\|^$\)', a:direction, a:visualmode ? visualmode() : '', 0)
+    " Note: Previous regex for all directions was '\(\(\<\|\>\|\s\)\@<=\S\|^$\)'
+    let l:regex_without_file_ends = '\v<|^\S|\s\zs\S|>\zs\S|^$'
+    let l:regex = l:regex_without_file_ends
+                \ . (a:direction == 1 ? '' : '|%$')
+                \ . (a:direction == 0 ? '' : '|%^')
+    call s:EasyMotion(l:regex, a:direction, a:visualmode ? visualmode() : '', 0)
     return s:EasyMotion_is_cancelled
 endfunction " }}}
 function! EasyMotion#E(visualmode, direction) " {{{

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -51,6 +51,7 @@ let g:EasyMotion_command_line_key_mappings =
     \ get(g: , 'EasyMotion_command_line_key_mappings' , {})
 let g:EasyMotion_disable_two_key_combo     =
     \ get(g: , 'EasyMotion_disable_two_key_combo' , 0)
+let g:EasyMotion_maximal_jumpmarks  = get(g: , 'EasyMotion_maximal_jumpmarks'  , 999)
 
 "}}}
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -51,7 +51,6 @@ let g:EasyMotion_command_line_key_mappings =
     \ get(g: , 'EasyMotion_command_line_key_mappings' , {})
 let g:EasyMotion_disable_two_key_combo     =
     \ get(g: , 'EasyMotion_disable_two_key_combo' , 0)
-let g:EasyMotion_maximal_jumpmarks  = get(g: , 'EasyMotion_maximal_jumpmarks'  , 999)
 
 "}}}
 

--- a/t/compare_movements_spec.vim
+++ b/t/compare_movements_spec.vim
@@ -201,8 +201,10 @@ describe 'Keyword word motion'
     end
 
     it 'Simple test to check setup of this test'
+        " Check if a is remapped to <Nop> to avoid start of insert mode.
         normal aa\<Esc>
         Expect getline(1) == ''
+
         call AddLine('word')
         Expect CompareMovements('w', 'w', 0) == 0
         Expect CompareMovements('w', '\wa', 0) == 0

--- a/t/compare_movements_spec.vim
+++ b/t/compare_movements_spec.vim
@@ -69,10 +69,10 @@ function! s:to_cursor.failure_message_for_should(actual, expected)
     Expect a:actual[1] > 0
     Expect a:expected[1] > 0
 
-    let l:line1 = getline(a:actual[0])
-    let l:line2 = getline(a:expected[0])
+    let line1 = getline(a:actual[0])
+    let line2 = getline(a:expected[0])
     " Change char on cursor to '█'. 
-    let l:line1 = strpart(l:line1, 0, a:actual[1]-1)
+    let line1 = strpart(l:line1, 0, a:actual[1]-1)
                 \ . '█'
                 \ . strpart(l:line1, a:actual[1])
     let line2 = strpart(l:line2, 0, a:expected[1]-1)
@@ -80,13 +80,13 @@ function! s:to_cursor.failure_message_for_should(actual, expected)
                 \ . strpart(l:line2, a:expected[1])
     " Separation of both cases with \n would be nice, but
     " vim-vspec allow oneliners as return string, only.
-    let l:msg = 'Line ' . string(a:actual[0]) . ": '" . l:line1
+    let msg = 'Line ' . string(a:actual[0]) . ": '" . l:line1
                 \ . "',\x09\x09 Line " . string(a:expected[0]) . ": '" . l:line2 . "'\x0a"
     return l:msg
 endfunction
 
 function! CompareMovements(movement1, movement2, backward)
-    let l:jumpmarks = [
+    let jumpmarks = [
                 \ [a:movement1, []],
                 \ [a:movement2, []],
                 \ ]
@@ -94,27 +94,27 @@ function! CompareMovements(movement1, movement2, backward)
     " Loop through current buffer in both variants {{
     for [l:handler, l:list] in l:jumpmarks
         if a:backward == 1
-            let l:last_line = line('$')
-            let l:last_char = len(getline(l:last_line))
+            let last_line = line('$')
+            let last_char = len(getline(l:last_line))
             call cursor(l:last_line, l:last_char)
         else
             call cursor([1,1])
         endif
 
-        let l:lastpos = [0,0]
+        let lastpos = [0,0]
 
         " Centralize line. Otherwise, Easymotion functions aborts
         " at the end of the (virtual) window.
         call TryNormal('zz')
         call TryNormal(l:handler)
-        let l:curpos = getpos(".")[1:2]
+        let curpos = getpos(".")[1:2]
 
         while l:lastpos != l:curpos 
-            let l:list += [l:curpos]
-            let l:lastpos = l:curpos
+            let list += [l:curpos]
+            let lastpos = l:curpos
             call TryNormal('zz')
             call TryNormal(l:handler)
-            let l:curpos = getpos(".")[1:2]
+            let curpos = getpos(".")[1:2]
             " Abort after a fixed number of steps.
             if len(l:list) > s:maximal_number_of_compared_movments
                 break
@@ -131,11 +131,11 @@ function! CompareMovements(movement1, movement2, backward)
     endif
 
     " Search for first unmatching position. {{
-    let l:index = 0
-    let l:len = min([len(l:cursor_positions2), len(l:cursor_positions1)]) 
+    let index = 0
+    let len = min([len(l:cursor_positions2), len(l:cursor_positions1)]) 
     while l:index < l:len
         Expect l:cursor_positions2[l:index] to_cursor l:cursor_positions1[l:index]
-        let l:index += 1
+        let index += 1
     endwhile
 
     " Collision with begin or end of file or while loop aborts to early.

--- a/t/compare_movements_spec.vim
+++ b/t/compare_movements_spec.vim
@@ -1,0 +1,190 @@
+"=============================================================================
+" FILE: t/compare_movements_spec.vim
+" AUTHOR: YggdrasiI
+" Test: https://github.com/kana/vim-vspec
+" Description: EasyMotion keyword movement test with vim-vspec
+" License: MIT license  {{{
+"     Permission is hereby granted, free of charge, to any person obtaining
+"     a copy of this software and associated documentation files (the
+"     "Software"), to deal in the Software without restriction, including
+"     without limitation the rights to use, copy, modify, merge, publish,
+"     distribute, sublicense, and/or sell copies of the Software, and to
+"     permit persons to whom the Software is furnished to do so, subject to
+"     the following conditions:
+"
+"     The above copyright notice and this permission notice shall be included
+"     in all copies or substantial portions of the Software.
+"
+"     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+"     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+"     MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+"     IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+"     CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+"     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+"     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+" }}}
+"=============================================================================
+
+" Setup {{{
+let s:root_dir = matchstr(system('git rev-parse --show-cdup'), '[^\n]\+')
+execute 'set' 'rtp +=./'.s:root_dir
+runtime! plugin/EasyMotion.vim
+" }}}
+
+" Functions for Test {{{
+function! AddLine(str)
+    put! =a:str
+endfunction
+
+function! CursorPos()
+    return [line('.'), col('.'), getline('.')[col('.')-1]]
+endfunction
+
+" Nested normal to avoid throwing readonly errors. They abort the testing.
+function TryNormal(str)
+    try
+        exec 'normal ' . a:str
+    catch /^Vim\%((\a\+)\)\=:E21/
+    endtry
+endfunction
+
+let s:to_cursor = {}
+function! s:to_cursor.match(actual, expected)
+    return a:actual == a:expected
+endfunction
+
+" Add metadata about failure.
+function! s:to_cursor.failure_message_for_should(actual, expected)
+    return ''
+    Expect a:actual[0] > 0
+    Expect a:expected[0] > 0
+    Expect a:actual[0] <= getpos('$')[1]
+    Expect a:expected[0] <= getpos('$')[1]
+    Expect a:actual[1] > 0
+    Expect a:expected[1] > 0
+
+    let l:line1 = getline(a:actual[0])
+    let l:line2 = getline(a:expected[0])
+    " Change char on cursor to '█'. 
+    let l:line1 = strpart(l:line1, 0, a:actual[1]-1)
+                \ . '█'
+                \ . strpart(l:line1, a:actual[1])
+    let line2 = strpart(l:line2, 0, a:expected[1]-1)
+                \ . '█'
+                \ . strpart(l:line2, a:expected[1])
+    let l:msg = 'Line ' . string(a:actual[0]) . ": '" . l:line1
+                \ . "', Line " . string(a:expected[0]) . ": '" . l:line2 . "'"
+    return l:msg
+endfunction
+
+function! CompareMovements(movement1, movement2, backward)
+    let l:jumpmarks = [
+                \ [a:movement1, []],
+                \ [a:movement2, []],
+                \ ]
+
+    " Loop through current buffer in both variants {{
+    for [l:handler, l:list] in l:jumpmarks
+        if a:backward == 1
+            call cursor(getpos('$')[1:2])
+        else
+            call cursor([1,1])
+        endif
+
+        let l:lastpos = [0,0]
+
+        call TryNormal(l:handler)
+        let l:curpos = getpos(".")[1:2]
+
+        while l:lastpos != l:curpos 
+            let l:list += [l:curpos]
+            let l:lastpos = l:curpos
+            call TryNormal(l:handler)
+            let l:curpos = getpos(".")[1:2]
+        endwhile
+    endfor
+    " }}
+
+    " The resulting lists are stored in l:jumpmarks[*][1], now.
+    let [l:cursor_positions1, l:cursor_positions2] = [ l:jumpmarks[0][1], l:jumpmarks[1][1] ]
+
+    " Debug output for this script
+    let g:dbg_msg = printf("(CompareMovements) '%s' vs '%s'\<CR>Length of both lists: %d, %d\r Content of lists:\r%s\r\r%s",
+                \ string(l:jumpmarks[0][0]),
+                \ string(l:jumpmarks[1][0]),
+                \ len(l:cursor_positions1), len(l:cursor_positions2),
+                \ string(l:cursor_positions1),
+                \ string(l:cursor_positions2))
+    Expect g:dbg_msg == v:errmsg
+
+    if l:cursor_positions1 == l:cursor_positions2
+        return 0
+    endif
+
+    " Search for first unmatching position. {{
+    let l:index = 0
+    let l:len = min([len(l:cursor_positions2), len(l:cursor_positions1)]) 
+    while l:index < l:len
+        Expect l:cursor_positions2[l:index] to_cursor l:cursor_positions1[l:index]
+        let l:index += 1
+    endwhile
+
+    " Collision with begin or end of file 
+    if a:backward == 1
+        Expect join(['File begin reached after ', len(l:cursor_positions2), ' steps.'])
+                    \ == join(['File begin reached after ', len(l:cursor_positions1), ' steps.'])
+    else
+        Expect join(['File end reached after ', len(l:cursor_positions2), ' steps.'])
+                    \ == join(['File end reached after ', len(l:cursor_positions1), ' steps.'])
+    endif
+    " }}
+
+    return -1
+endfunction
+"}}}
+
+"Keyword word motion {{{
+describe 'Keyword word motion'
+    before
+        new
+        nmap a <Nop>
+        let g:EasyMotion_keys = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        nmap <Leader>w <Plug>(easymotion-iskeyword-w)
+        nmap <Leader>b <Plug>(easymotion-iskeyword-b)
+        call EasyMotion#init()
+
+        call vspec#customize_matcher('to_cursor', s:to_cursor)
+    end
+
+    after
+        close!
+    end
+
+    it 'Simple test to check setup of this test'
+        call AddLine('word')
+        Expect CompareMovements('w', '\wa', 0) == 0
+        "Expect CompareMovements('b', '\ba', 1) == 0
+    end
+
+    "it 'Loop through hand crafted text with rare cases'
+    "    " Hand crafted text with rare cases
+    "    call AddLine('scriptencoding utf-8')
+    "    call AddLine('Test case [ ')
+    "    call AddLine('<!{}>s!  ')
+    "    Expect CompareMovements('w', '\wa', 0) == 0
+    "    Expect CompareMovements('b', '\ba', 1) == 0
+    "end
+
+    "it 'Loop through Vim help buffer and compare movements'
+    "    help motion.txt
+    "    Expect expand('%:t') ==# 'motion.txt'
+    "    "Expect CompareMovements('w', '\wa', 0) == 0
+    "    "Expect CompareMovements('b', '\ba', 1) == 0
+    "end
+
+end
+"}}}
+
+" __END__  {{{
+" vim: fdm=marker:et:ts=4:sw=4:sts=4
+" }}}

--- a/t/easymotion_spec.vim
+++ b/t/easymotion_spec.vim
@@ -217,7 +217,7 @@ describe 'Default settings'
         "}}}
     end
 
-    it 'provide default <Plug> mappings for regrex motion'
+    it 'provide default <Plug> mappings for regex motion'
         "(is_visual, direction)
         " direction:
         "   - 0: forward
@@ -1411,8 +1411,8 @@ describe 'Word motion'
         close!
     end
 
-    " Default word motion {{
-    it 'Default word motion'
+    " Word motion {{
+    it 'Word motion'
         normal! 0
         let l = line('.')
         Expect CursorPos() == [l,1,'p']
@@ -1430,7 +1430,7 @@ describe 'Word motion'
         normal bh
         Expect CursorPos() == [l,1,'p']
     end
-    "}}}
+    "}}
 end
 
 describe 'Verbose'


### PR DESCRIPTION
This is a pull request for [Issue 267](https://github.com/easymotion/vim-easymotion/issues/267).
It changes the regexes for w, b, e, ge, W, B, E and gE to match more with Vim's default. For the first four motions, the iskeyword-variant was changed.

The pulled request contain a new test file, too. The main function, CompareMovements, expect two normal movement commands, like 'w' and '\\wa'. It loops through the current buffer and compare the cursor positions.
One test (on a vim help page) was commented out due it's long duration.

Note that I've added the option EasyMotion_maximal_jumpmarks to abort the creation of the jumpmarks after two steps in the test file. (Aborting after only one step fails for unknown reasons.)
If the options is undesired it could be removed easily. 


Regards YggdrasiI