### PR TITLE
Timeout feature + search highlight switch

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -128,8 +128,12 @@ endfunction "}}}
 " direction:
 "   0 -> forward
 "   1 -> backward
-"   2 -> bi-direction (handle forward & backward at the same time) }}}
-function! EasyMotion#S(num_strokes, visualmode, direction) " {{{
+"   2 -> bi-direction (handle forward & backward at the same time)
+" timeout:
+"   Takes only values of 1 and 0, meaning, respectively, to use or not to use
+"   timeout when getting user input. Timeout length itself is controlled
+"   by gloabal variable }}}
+function! EasyMotion#S(num_strokes, visualmode, direction, ...) " {{{
     if a:direction == 1
         let is_inclusive = 0
     else
@@ -138,7 +142,7 @@ function! EasyMotion#S(num_strokes, visualmode, direction) " {{{
         let is_inclusive = mode(1) ==# 'no' ? 1 : 0
     endif
     let s:flag.find_bd = a:direction == 2 ? 1 : 0
-    let re = s:findMotion(a:num_strokes, a:direction)
+    let re = s:findMotion(a:num_strokes, a:direction, get(a:, 0, 0))
     if s:handleEmpty(re, a:visualmode) | return | endif
     call s:EasyMotion(re, a:direction, a:visualmode ? visualmode() : '', is_inclusive)
     return s:EasyMotion_is_cancelled
@@ -150,7 +154,7 @@ function! EasyMotion#OverwinF(num_strokes) " {{{
         return EasyMotion#overwin#move(re)
     endif
 endfunction "}}}
-function! EasyMotion#T(num_strokes, visualmode, direction) " {{{
+function! EasyMotion#T(num_strokes, visualmode, direction, timeout) " {{{
     if a:direction == 1
         let is_inclusive = 0
     else
@@ -159,7 +163,7 @@ function! EasyMotion#T(num_strokes, visualmode, direction) " {{{
         let is_inclusive = mode(1) ==# 'no' ? 1 : 0
     endif
     let s:flag.find_bd = a:direction == 2 ? 1 : 0
-    let re = s:findMotion(a:num_strokes, a:direction)
+    let re = s:findMotion(a:num_strokes, a:direction, get(a:, 0, 0))
     if s:handleEmpty(re, a:visualmode) | return | endif
     if a:direction == 2
         let s:flag.bd_t = 1
@@ -275,14 +279,14 @@ function! EasyMotion#JumpToAnywhere(visualmode, direction) " {{{
     return s:EasyMotion_is_cancelled
 endfunction " }}}
 " -- Line Motion -------------------------
-function! EasyMotion#SL(num_strokes, visualmode, direction) " {{{
+function! EasyMotion#SL(num_strokes, visualmode, direction, timeout) " {{{
     let s:flag.within_line = 1
-    call EasyMotion#S(a:num_strokes, a:visualmode, a:direction)
+    call EasyMotion#S(a:num_strokes, a:visualmode, a:direction, get(a:, 0, 0))
     return s:EasyMotion_is_cancelled
 endfunction " }}}
-function! EasyMotion#TL(num_strokes, visualmode, direction) " {{{
+function! EasyMotion#TL(num_strokes, visualmode, direction, timeout) " {{{
     let s:flag.within_line = 1
-    call EasyMotion#T(a:num_strokes, a:visualmode, a:direction)
+    call EasyMotion#T(a:num_strokes, a:visualmode, a:direction, get(a:, 0, 0))
     return s:EasyMotion_is_cancelled
 endfunction " }}}
 function! EasyMotion#WBL(visualmode, direction) " {{{
@@ -524,13 +528,14 @@ function! s:GetChar(...) abort "{{{
 endfunction "}}}
 
 " -- Find Motion Helper ------------------
-function! s:findMotion(num_strokes, direction) "{{{
+function! s:findMotion(num_strokes, direction, ...) "{{{
     " Find Motion: S,F,T
     let s:current.is_operator = mode(1) ==# 'no' ? 1: 0
     " store cursor pos because 'n' key find motion could be jump to offscreen
     let s:current.original_position = [line('.'), col('.')]
     let s:current.is_search = a:num_strokes == -1 ? 1: 0
     let s:flag.regexp = a:num_strokes == -1 ? 1 : 0 " TODO: remove?
+    let timeout = get(a:, 1, 0)
 
     if g:EasyMotion_add_search_history && a:num_strokes == -1
         let s:previous['input'] = @/
@@ -538,7 +543,8 @@ function! s:findMotion(num_strokes, direction) "{{{
         let s:previous['input'] = get(s:previous, 'input', '')
     endif
     let input = EasyMotion#command_line#GetInput(
-                    \ a:num_strokes, s:previous.input, a:direction)
+                    \ a:num_strokes, s:previous.input,
+                    \ a:direction, timeout)
     let s:previous['input'] = input
 
     " Check that we have an input char

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1573,6 +1573,11 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
             call EasyMotion#helper#silent_feedkeys(
                                     \ ":let &hlsearch=&hlsearch\<CR>",
                                     \ 'hlsearch', 'n')
+            if !g:EasyMotion_history_highlight
+                call EasyMotion#helper#silent_feedkeys(
+                                        \ ":noh\<CR>",
+                                        \ 'noh', 'n')
+            endif
         endif "}}}
 
         call s:Message('Jumping to [' . coords[0] . ', ' . coords[1] . ']')

--- a/autoload/EasyMotion/command_line.vim
+++ b/autoload/EasyMotion/command_line.vim
@@ -140,10 +140,14 @@ function! s:search.on_leave(cmdline) "{{{
         if g:EasyMotion_do_shade
             call EasyMotion#highlight#delete_highlight(g:EasyMotion_hl_group_shade)
         endif
+        if s:timeout
+            call s:stop_timer()
+        endif
     endif
     if g:EasyMotion_cursor_highlight
         call EasyMotion#highlight#delete_highlight(g:EasyMotion_hl_inc_cursor)
     endif
+    noh
 endfunction "}}}
 function! s:search.on_char(cmdline) "{{{
     if s:num_strokes == -1
@@ -160,6 +164,9 @@ function! s:search.on_char(cmdline) "{{{
         if g:EasyMotion_off_screen_search
             call s:off_screen_search(re)
         endif
+        if s:timeout
+            call s:restart_timer()
+        endif
     elseif s:search.line.length() >=  s:num_strokes
         call s:search.exit()
     endif
@@ -167,8 +174,9 @@ endfunction "}}}
 "}}}
 
 " Main:
-function! EasyMotion#command_line#GetInput(num_strokes, prev, direction) "{{{
+function! EasyMotion#command_line#GetInput(num_strokes, prev, direction, timeout) "{{{
     let s:num_strokes = a:num_strokes
+    let s:timeout = a:timeout
 
     let s:prompt_base = s:getPromptMessage(a:num_strokes)
     call s:search.set_prompt(s:prompt_base)
@@ -273,6 +281,27 @@ function! s:inc_highlight(re) "{{{
     if s:search.line.length() > 0
         " Error occur when '\zs' without '!'
         silent! call EasyMotion#highlight#add_highlight(a:re, g:EasyMotion_hl_inc_search)
+    endif
+endfunction "}}}
+
+function! s:start_timer() "{{{
+    if version >= 800
+        let s:timer_id = timer_start(g:EasyMotion_timeout_len, {-> feedkeys("\<CR>")})
+    endif
+endfunction "}}}
+
+function! s:stop_timer() "{{{
+    if version >= 800
+        if exists('s:timer_id')
+            call timer_stop(s:timer_id)
+        endif
+    endif
+endfunction "}}}
+
+function! s:restart_timer() "{{{
+    if version >= 800
+        call s:stop_timer()
+        call s:start_timer()
     endif
 endfunction "}}}
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -45,6 +45,7 @@ let g:EasyMotion_off_screen_search  = get(g: , 'EasyMotion_off_screen_search'  ,
 let g:EasyMotion_force_csapprox     = get(g: , 'EasyMotion_force_csapprox'     , 0)
 let g:EasyMotion_show_prompt        = get(g: , 'EasyMotion_show_prompt'        , 1)
 let g:EasyMotion_verbose            = get(g: , 'EasyMotion_verbose'            , 1)
+let g:EasyMotion_history_highlight  = get(g: , 'EasyMotion_history_highlight'  , 1)
 let g:EasyMotion_prompt             =
     \ get(g: , 'EasyMotion_prompt' , 'Search for {n} character(s): ')
 let g:EasyMotion_command_line_key_mappings =

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -52,6 +52,10 @@ let g:EasyMotion_command_line_key_mappings =
 let g:EasyMotion_disable_two_key_combo     =
     \ get(g: , 'EasyMotion_disable_two_key_combo' , 0)
 
+if version >= 800
+    let g:EasyMotion_timeout_len    = get(g: , 'EasyMotion_timeout_len'        , 500)
+endif
+
 "}}}
 
 " }}}
@@ -67,6 +71,10 @@ function! s:motion_map_helper(motions) "{{{
         if dict.fnc ==# 'S' || dict.fnc ==# 'SL' || dict.fnc ==# 'T' || dict.fnc ==# 'TL'
             let mapargs  += [dict.cnt, 0, dict.direction]
             let xmapargs += [dict.cnt, 1, dict.direction]
+            if has_key(dict, 'timeout')
+                let mapargs  += [dict.timeout]
+                let xmapargs += [dict.timeout]
+            endif
         elseif dict.fnc ==# 'Search'
             let mapargs  += [0, dict.direction, dict.respect_direction]
             let xmapargs += [1, dict.direction, dict.respect_direction]
@@ -131,6 +139,21 @@ call s:motion_map_helper({
     \ 'tln'             : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 0},
     \ 'Tln'             : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 1},
     \ 'bd-tln'          : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 2},
+    \
+    \ 'fn-to'           : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 0, 'timeout' : 1},
+    \ 'Fn-to'           : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 1, 'timeout' : 1},
+    \ 'sn-to'           : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
+    \ 'bd-fn-to'        : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
+    \ 'tn-to'           : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 0, 'timeout' : 1},
+    \ 'Tn-to'           : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 1, 'timeout' : 1},
+    \ 'bd-tn-to'        : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
+    \ 'fln-to'          : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 0, 'timeout' : 1},
+    \ 'Fln-to'          : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 1, 'timeout' : 1},
+    \ 'sln-to'          : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
+    \ 'bd-fln-to'       : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
+    \ 'tln-to'          : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 0, 'timeout' : 1},
+    \ 'Tln-to'          : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 1, 'timeout' : 1},
+    \ 'bd-tln-to'       : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 2, 'timeout' : 1},
     \ })
 
 nnoremap <silent> <Plug>(easymotion-overwin-f) :<C-u>call EasyMotion#OverwinF(1)<CR>


### PR DESCRIPTION
As Vim 8 is out now, I have implemented what is was missing from emacs' evil-easymotion - n characters search with timeout (so when you start typing characters you want to search for, you don't have to click enter to search them - saves 1 (!) keystroke :) It makes searching more dynamic though, at least for me).

I have also added a switch, which allows to have incremental highlighting when typing, without all matches highlighted after jumping to desired location.
