### PR TITLE
Use faster highlighting when available

### DIFF
--- a/autoload/EasyMotion/highlight.vim
+++ b/autoload/EasyMotion/highlight.vim
@@ -176,6 +176,13 @@ endfunction "}}}
 function! EasyMotion#highlight#add_pos_highlight(line_num, col_num, group) "{{{
     call add(s:h.ids[a:group], matchaddpos(a:group, [[a:line_num, a:col_num]], s:priorities[a:group]))
 endfunction "}}}
+function! EasyMotion#highlight#add_pos_highlight_batch(pos_list, group) "{{{
+    let n = len(a:pos_list)
+    for i in range(0, n - 1, 8)
+        call add(s:h.ids[a:group], matchaddpos(a:group, a:pos_list[i:i + 7], s:priorities[a:group]))
+    endfor
+    call add(s:h.ids[a:group], matchaddpos(a:group, a:pos_list[(n / 8) * 8:], s:priorities[a:group]))
+endfunction "}}}
 function! EasyMotion#highlight#attach_autocmd() "{{{
     " Reference: https://github.com/justinmk/vim-sneak
     augroup plugin-easymotion


### PR DESCRIPTION
Using matchaddpos on each position individually has a lot of overhead, which causes vim to lag while it's highlighting too many targets. I've written two alternatives:
  - The first one builds a list of targets, then sends them to matchaddpos in batches of 8, which is the current limit.
  - The second one uses neovim api, which seems to be even more efficient.

I've compared the three methods on my machine using vim's profiler.  
On a file with ~4k targets (61 lines, each containing 65 "aaa "s), the old method finishes highlights the targets in 4.3s, the batch method in 1.45s, and the neovim api in 1.05s.