### PR TITLE
Add autocommands to notice linters

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1095,6 +1095,9 @@ function! s:PromptUser(groups) "{{{
     let lines_items = items(lines)
     " }}}
 
+    " Invoke autocmd so the user can temporarily disable linters, etc.
+    doautocmd User EasyMotionPromptBegin
+
     " -- Put labels on targets & Get User Input & Restore all {{{
     " Save undo tree
     let undo_lock = EasyMotion#undo#save()
@@ -1148,6 +1151,9 @@ function! s:PromptUser(groups) "{{{
         call undo_lock.restore()
 
         redraw
+
+        " Invoke autocmd
+        doautocmd User EasyMotionPromptEnd
     endtry "}}}
 
     " -- Check if we have an input char ------ {{{

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -38,6 +38,7 @@ CONTENTS                                                 *easymotion-contents*
        Custom mappings ................. |easymotion-custom-mappings|
            Leader key .................. |easymotion-leader-key|
            Custom keys ................. |easymotion-custom-keys|
+       Autocommands .................... |easymotion-autocommands|
     License ............................ |easymotion-license|
     Known bugs ......................... |easymotion-known-bugs|
     Contributing ....................... |easymotion-contributing|
@@ -1139,8 +1140,9 @@ Example: >
 See |easymotion-plug-table| for a table of motions that can be mapped
 and their default values.
 
-Autocommands                                           *easymotion-autocommands*
-                                   *EasyMotionPromptBegin* *EasyMotionPromptEnd*
+------------------------------------------------------------------------------
+Autocommands                                          *easymotion-autocommands*
+                                    *EasyMotionPromptBegin* *EasyMotionPromptEnd*
 
 EasyMotion invokes two |User| autocommands, |EasyMotionPromptBegin| and
 |EasyMotionPromptEnd|, so you can temporarily disable your linter to avoid

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -1139,6 +1139,28 @@ Example: >
 See |easymotion-plug-table| for a table of motions that can be mapped
 and their default values.
 
+Autocommands                                           *easymotion-autocommands*
+                                   *EasyMotionPromptBegin* *EasyMotionPromptEnd*
+
+EasyMotion invokes two |User| autocommands, |EasyMotionPromptBegin| and
+|EasyMotionPromptEnd|, so you can temporarily disable your linter to avoid
+annoying syntax errors.
+
+
+EasyMotionPromptBegin       Before the content of buffer is changed with
+                            markers. If EasyMotion directly jumps to the
+                            target (no prompts given), this autocommand will
+                            not be executed.
+
+EasyMotionPromptEnd         After the content of buffer and the undo tree are
+                            restored.
+
+Example with coc.nvim: >
+
+    autocmd User EasyMotionPromptBegin silent! CocDisable
+    autocmd User EasyMotionPromptEnd   silent! CocEnable
+<
+
 ==============================================================================
 License                                                    *easymotion-license*
 


### PR DESCRIPTION
This change addresses #402 for linters that provide enable/disable commands.
I'm not very familiar with vimscript, so please check.

As mentioned in the #402, the best workaround so far is probably attach an autocommand to `TextChanged` and `CursorMoved` and manually check whether EasyMotion is active. This makes the process much simpler. Linter plugin authors can also easily support EasyMotion.