### PR TITLE
Fix 'No matching autocommands' warning caused by #437

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1095,6 +1095,9 @@ function! s:PromptUser(groups) "{{{
     let lines_items = items(lines)
     " }}}
 
+    " Invoke autocmd so the user can temporarily disable linters, etc.
+    silent doautocmd User EasyMotionPromptBegin
+
     " -- Put labels on targets & Get User Input & Restore all {{{
     " Save undo tree
     let undo_lock = EasyMotion#undo#save()
@@ -1148,6 +1151,9 @@ function! s:PromptUser(groups) "{{{
         call undo_lock.restore()
 
         redraw
+
+        " Invoke autocmd
+        silent doautocmd User EasyMotionPromptEnd
     endtry "}}}
 
     " -- Check if we have an input char ------ {{{

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -1,4 +1,4 @@
-*easymotion.txt*	Version 3.0
+*easymotion.txt*        Version 3.0
 
 
             ______                  __  ___       __  _
@@ -38,6 +38,7 @@ CONTENTS                                                 *easymotion-contents*
        Custom mappings ................. |easymotion-custom-mappings|
            Leader key .................. |easymotion-leader-key|
            Custom keys ................. |easymotion-custom-keys|
+       Autocommands .................... |easymotion-autocommands|
     License ............................ |easymotion-license|
     Known bugs ......................... |easymotion-known-bugs|
     Contributing ....................... |easymotion-contributing|
@@ -1138,6 +1139,28 @@ Example: >
 <
 See |easymotion-plug-table| for a table of motions that can be mapped
 and their default values.
+
+------------------------------------------------------------------------------
+Autocommands                                          *easymotion-autocommands*
+                                    *EasyMotionPromptBegin* *EasyMotionPromptEnd*
+
+EasyMotion invokes two |User| autocommands, |EasyMotionPromptBegin| and
+|EasyMotionPromptEnd|, so you can temporarily disable your linter to avoid
+annoying syntax errors.
+
+EasyMotionPromptBegin       Before the content of buffer is changed with
+                            markers. If EasyMotion directly jumps to the
+                            target (no prompts given), this autocommand will
+                            not be executed.
+
+EasyMotionPromptEnd         After the content of buffer and the undo tree are
+                            restored.
+
+Example with coc.nvim: >
+
+    autocmd User EasyMotionPromptBegin silent! CocDisable
+    autocmd User EasyMotionPromptEnd   silent! CocEnable
+<
 
 ==============================================================================
 License                                                    *easymotion-license*


### PR DESCRIPTION
The warning only appears in Vim. I only tested on Neovim and did not notice the warning. It is fixed now.

I'm sorry for the mess.