### PR TITLE
Add Vim-Plug and Vim8 Native installation help

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ Plugin 'easymotion/vim-easymotion'
 NeoBundle 'easymotion/vim-easymotion'
 ```
 
+### Vim-Plug (https://github.com/junegunn/vim-plug)
+```
+Plug 'easymotion/vim-easymotion'
+```
+
+### Vim8 Native Plugin Manager (https://vimhelp.org/repeat.txt.html#packages)
+```
+git clone https://github.com/easymotion/vim-easymotion ~/.vim/pack/plugins/start/vim-easymotion
+```
+
 Minimal Configuration Tutorial
 ------------------------------
 **I recommend configuring and map keys by yourself if you are true Vimmer.**

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Plug 'easymotion/vim-easymotion'
 
 ### Vim8 Native Plugin Manager (https://vimhelp.org/repeat.txt.html#packages)
 ```
-git clone https://github.com/easymotion/vim-easymotion ~/.vim/pack/plugins/start/vim-easymotion
+git clone https://github.com/easymotion/vim-easymotion.git ~/.vim/pack/plugins/start/vim-easymotion
 ```
 
 Minimal Configuration Tutorial


### PR DESCRIPTION
Vim-Plug is one of the most popular Vim plugin managers by stars on Github, and so should be one of the methods to have its usage described in the installation section.
Vim8 has native plugin management, allowing all Vim8 users to use it without installing additional plugins. For this reason a usage method should also be added.