### PR TITLE
`a:` -> `a:000`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ function! s:incsearch_config(...) abort
   \     "\<CR>": '<Over>(easymotion)'
   \   },
   \   'is_expr': 0
-  \ }), get(a:, 1, {}))
+  \ }), get(a:000, 1, {}))
 endfunction
 
 noremap <silent><expr> /  incsearch#go(<SID>incsearch_config())
@@ -172,7 +172,7 @@ function! s:config_easyfuzzymotion(...) abort
   \   'keymap': {"\<CR>": '<Over>(easymotion)'},
   \   'is_expr': 0,
   \   'is_stay': 1
-  \ }), get(a:, 1, {}))
+  \ }), get(a:000, 1, {}))
 endfunction
 
 noremap <silent><expr> <Space>/ incsearch#go(<SID>config_easyfuzzymotion())


### PR DESCRIPTION
nvim-treesitter is not able to grasp `a:`  (like bellow picture Figure1).
All codes under this setting turn into no color.

Therefore I replaced `a:` with `a:000` (Figure 2).

`Figure 1`
![nvim-treesitter is not able to grasp a:](https://user-images.githubusercontent.com/42632201/156915923-d92437ed-4e40-40d3-bea2-f338750bcf27.png)

`Figure 2`
![スクリーンショット 2022-03-06 17 54 29](https://user-images.githubusercontent.com/42632201/156916076-e05efb60-90ed-454b-98ff-3cca84dcfb04.png)

