### PR TITLE
docs: ask coc to refresh after easymotion actions

### DIFF
--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -1159,7 +1159,7 @@ EasyMotionPromptEnd         After the content of buffer and the undo tree are
 Example with coc.nvim: >
 
     autocmd User EasyMotionPromptBegin silent! CocDisable
-    autocmd User EasyMotionPromptEnd   silent! CocEnable
+    autocmd User EasyMotionPromptEnd   silent! CocEnable \| call coc#refresh()
 <
 
 ==============================================================================


### PR DESCRIPTION
Before, it will leave the texts as is, without checking syntax, typo... until the next edit finishes