### PR TITLE
Detect migemo dictionaries installed outside of /usr

### DIFF
--- a/autoload/EasyMotion/cmigemo.vim
+++ b/autoload/EasyMotion/cmigemo.vim
@@ -51,6 +51,13 @@ function! s:SearchDict2(name) "{{{
     if dict == ''
         let dict = globpath(path, a:name)
     endif
+
+    let migemopath = exepath('cmigemo')
+    if migemopath != ''
+        let migemodir = fnamemodify(migemopath, ':h:h')
+        let dict = globpath(migemodir, 'share/{,c}migemo/'.a:name)
+    endif
+
     if dict == ''
         for path in [
                 \ '/usr/local/share/migemo/',


### PR DESCRIPTION
This improves the detection logic for migemo dictionaries so that it would properly detect dictionaries installed in unconventional locations. It makes easymotion search for the dictionaries relative to cmigemo's location in `$PATH` in addition to the existing search paths.
