### PR TITLE
Fix syntax error in example in documentation.

### DIFF
--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -358,7 +358,7 @@ Jump To Anywhere ~
     let g:EasyMotion_re_anywhere = '\v' .
         \       '(<.|^)' . '|' .
         \       '(<.|.$)' . '|' .
-        \       '(\l)\zs(\u)' . '|' .
+        \       '(\l)\zs(\u)' . '|'
 <
 Repeat ~
 


### PR DESCRIPTION
I tried dopy-pasting the example into my vim config, but got an error