### PR TITLE
Added Autocommands for initial inputs

### DIFF
--- a/autoload/EasyMotion/command_line.vim
+++ b/autoload/EasyMotion/command_line.vim
@@ -173,6 +173,9 @@ function! EasyMotion#command_line#GetInput(num_strokes, prev, direction) "{{{
     let s:prompt_base = s:getPromptMessage(a:num_strokes)
     call s:search.set_prompt(s:prompt_base)
 
+    " Invoke autocmd so the user can temporarily hide floating popups, etc.
+    silent doautocmd User EasyMotionInputBegin
+
     " Screen: cursor position, first and last line
     let s:orig_pos = getpos('.')
     let s:orig_line_start = getpos('w0')
@@ -184,6 +187,8 @@ function! EasyMotion#command_line#GetInput(num_strokes, prev, direction) "{{{
     let s:save_direction = deepcopy(s:direction)
 
     let input = s:search.get()
+    silent doautocmd User EasyMotionInputEnd
+
     if input == '' && ! s:search.exit_code()
         return a:prev
     elseif s:search.exit_code() == 1 || s:search.exit_code() == -1

--- a/doc/easymotion.txt
+++ b/doc/easymotion.txt
@@ -1143,10 +1143,17 @@ and their default values.
 ------------------------------------------------------------------------------
 Autocommands                                          *easymotion-autocommands*
                                     *EasyMotionPromptBegin* *EasyMotionPromptEnd*
+                                    *EasyMotionInputBegin* *EasyMotionInputEnd*
 
-EasyMotion invokes two |User| autocommands, |EasyMotionPromptBegin| and
+EasyMotion invokes four |User| autocommands, |EasyMotionPromptBegin| and
 |EasyMotionPromptEnd|, so you can temporarily disable your linter to avoid
-annoying syntax errors.
+annoying syntax errors, and |EasyMotionInputBegin| and |EasyMotionInputEnd|,
+so you can temporarily hide floating popups and windows that hide buffer text.
+
+EasyMotionInputBegin        Before EasyMotion asks for input of characters
+                            (with S/F/T commands).
+EasyMotionInputEnd          After EasyMotion got the input, or the operation
+                            was cancelled.
 
 EasyMotionPromptBegin       Before the content of buffer is changed with
                             markers. If EasyMotion directly jumps to the
@@ -1158,7 +1165,8 @@ EasyMotionPromptEnd         After the content of buffer and the undo tree are
 
 Example with coc.nvim: >
 
-    autocmd User EasyMotionPromptBegin silent! CocDisable
+    autocmd User EasyMotionInputBegin  silent! call coc#float#close_all()
+        autocmd User EasyMotionPromptBegin silent! CocDisable
     autocmd User EasyMotionPromptEnd   silent! CocEnable
 <
 


### PR DESCRIPTION
To complete the integration with other plugins as started in [this PR](https://github.com/easymotion/vim-easymotion/pull/440) that added `EasyMotionPromptBegin/End`, I added `EasyMotionInputBegin/End`, so that floating popup windows could be hidden, as they hide the matches the EasyMotion prints.

In the video, I want to get somewhere in the comment on line 15, but when running `easymotion-s`, EasyMotion asks for a character to jump to, and I can't see the line I want to jump to, in order to decide the character to input, because it's hidden by the COC popup:
https://github.com/easymotion/vim-easymotion/assets/47110179/20daeec8-e673-44ce-b85c-8b1ae8d2af10


